### PR TITLE
small fixes and cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+target

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Use /se <element> or /switchelement <element> <br>
 Elements: white/anemo/geo/electro <br>
 white = no element <br><br>
 
+## Building
+I don't know why would you want to build it but:
+1. Download maven from apache website
+2. Open command prompt/powershell in your project folder
+3. Run <b>mvn package</b>
+4. Now jar file should be in new tasrget folder
 
 ### Version
 The plugin is based on plugin template from Grasscutters GitHub.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
 # SwitchElement
 Simple, mostly stolen script from one of pr in official gc, which allows to quickly change traveller element.<br>
 Original pr: https://github.com/Grasscutters/Grasscutter/pull/1287 <br>
-I just added dendro (not this version, ask dm Penelopeep#7963) and changed it to plugin.
+I just changed it to plugin.
 
 ## Usage
 Use /se <element> or /switchelement <element> <br>
-Elements: white/anemo/geo/electro
-white = no element
+Elements: white/anemo/geo/electro <br>
+white = no element <br><br>
 
-### Issues
-
-I know that descriptions are missing, don't use issues on github, I promise that I'll fix that
 
 ### Version
 The plugin is based on plugin template from Grasscutters GitHub.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ white = no element <br><br>
 ## Building
 I don't know why would you want to build it but:
 1. Download maven from apache website
-2. Open command prompt/powershell in your project folder
+2. Open command prompt/powershell in your project folder (Sorry Linux and MacOS users, you'll need to find your own way for this)
 3. Run <b>mvn package</b>
 4. Now jar file should be in new tasrget folder
 

--- a/src/main/java/test/gc/switchele/VersionSupportHelper.java
+++ b/src/main/java/test/gc/switchele/VersionSupportHelper.java
@@ -1,0 +1,26 @@
+package test.gc.switchele;
+
+import emu.grasscutter.game.player.Player;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Method;
+
+public class VersionSupportHelper {
+    /**
+     * 1.2.3 changed the player api, so we need to use reflections to get the proper method for the server instance
+     *
+     * @return method reference for getting the current position from a player object. Return null if it was unable to find it
+     */
+    @Nullable
+    public static Method getPositionMethod() {
+        try {
+            return Player.class.getMethod("getPos");
+        } catch (NoSuchMethodException ignored) {
+        }
+        try {
+            return Player.class.getMethod("getPosition");
+        } catch (NoSuchMethodException ignored) {
+        }
+        return null;
+    }
+}

--- a/src/main/java/test/gc/switchele/commands/Element.java
+++ b/src/main/java/test/gc/switchele/commands/Element.java
@@ -1,0 +1,29 @@
+package test.gc.switchele.commands;
+
+import emu.grasscutter.GameConstants;
+
+public enum Element {
+    COMMON(501, 701),
+    FIRE(502, 702),
+    WATER(503, 703),
+    WIND(504, 704),
+    ICE(505, 705),
+    ROCK(506, 706),
+    ELECTRO(507, 707),
+    GRASS(508, 708);
+    private final int boyId;
+    private final int girlId;
+
+    Element(int boyId, int girlId) {
+        this.boyId = boyId;
+        this.girlId = girlId;
+    }
+
+    public int getSkillRepoId(boolean isBoy) {
+        return isBoy ? boyId : girlId;
+    }
+
+    public int getSkillRepoId(int avatarId) {
+        return avatarId == GameConstants.MAIN_CHARACTER_MALE ? boyId : girlId;
+    }
+}

--- a/src/main/java/test/gc/switchele/commands/SwitchElement.java
+++ b/src/main/java/test/gc/switchele/commands/SwitchElement.java
@@ -4,20 +4,47 @@ import emu.grasscutter.GameConstants;
 import emu.grasscutter.command.Command;
 import emu.grasscutter.command.CommandHandler;
 import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.excels.AvatarSkillDepotData;
 import emu.grasscutter.game.avatar.Avatar;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.server.packet.send.PacketSceneEntityAppearNotify;
 import test.gc.switchele.Switchele;
 
-import java.util.ArrayList;
 import java.util.List;
 
-@Command(label = "switchelement", description = "Switch element for traveller", usage = "switchelement [White/Anemo/Geo/Electro]", aliases = {"se"}, threading = true)
+@Command(label = "switchelement", description = "Switch element for traveller", usage = "switchelement [White/Anemo/Geo/Electro/Dendro]", aliases = {"se"}, threading = true)
 public class SwitchElement implements CommandHandler {
+
+    private Element getElementFromString(String elementString) {
+        return switch (elementString.toLowerCase()) {
+            case "white", "common" -> Element.COMMON;
+            case "fire", "pyro" -> Element.FIRE;
+            case "water", "hydro" -> Element.WATER;
+            case "wind", "anemo" -> Element.WIND;
+            case "ice", "cryo" -> Element.ICE;
+            case "rock", "geo" -> Element.ROCK;
+            case "electro" -> Element.ELECTRO;
+            case "grass", "dendro", "plant" -> Element.GRASS;
+            default -> null;
+        };
+    }
+
+    private boolean changeAvatarElement(Player sender, int avatarId, Element element) {
+        Avatar avatar = sender.getAvatars().getAvatarById(avatarId);
+        AvatarSkillDepotData skillDepot = GameData.getAvatarSkillDepotDataMap().get(element.getSkillRepoId(avatarId));
+        if (avatar == null || skillDepot == null) {
+            return false;
+        }
+        avatar.setSkillDepotData(skillDepot);
+        avatar.setCurrentEnergy(1000);
+        avatar.save();
+        return true;
+    }
+
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (args.size() != 1) {
-            CommandHandler.sendMessage(sender, "Usage: /se OR /switchelement [White/Anemo/Geo/Electro]");
+            CommandHandler.sendMessage(sender, "Usage: /se OR /switchelement [White/Anemo/Geo/Electro/Dendro]");
             return;
         }
         if (sender == null) {
@@ -25,46 +52,25 @@ public class SwitchElement implements CommandHandler {
             return;
         }
 
-        String element = args.get(0);
+        Element element = getElementFromString(args.get(0));
 
-        Integer elementId = switch (element.toLowerCase()) {
-            case "white" -> 501;
-            case "anemo" -> 504;
-            case "geo" -> 506;
-            case "electro" -> 507;
-            default -> null;
-        };
 
-        if (elementId == null) {
+        if (element == null) {
             CommandHandler.sendMessage(sender, "Invalid element");
             return;
         }
 
-        List<Integer> id = new ArrayList<>();
-        id.add(GameConstants.MAIN_CHARACTER_MALE);
-        id.add(GameConstants.MAIN_CHARACTER_FEMALE);
-
-
-        try {
-            for (int i : id) {
-                Avatar avatar
-                        = sender.getAvatars().getAvatarById(i);
-                if (avatar != null) {
-                    avatar.setSkillDepotData(GameData.getAvatarSkillDepotDataMap().get(elementId));
-                    avatar.setCurrentEnergy(1000);
-                    avatar.save();
-                }
-            }
-            String success = String.format("Successfully changed element to %s", element);
-            CommandHandler.sendMessage(sender,success);
+        boolean maleSuccess = changeAvatarElement(sender, GameConstants.MAIN_CHARACTER_MALE, element);
+        boolean femaleSuccess = changeAvatarElement(sender, GameConstants.MAIN_CHARACTER_FEMALE, element);
+        if (maleSuccess || femaleSuccess) {
+            String success = String.format("Successfully changed element to %s", element.name());
+            CommandHandler.sendMessage(sender, success);
             int scene = sender.getSceneId();
             sender.getWorld().transferPlayerToScene(sender, 1, sender.getPos());
             sender.getWorld().transferPlayerToScene(sender, scene, sender.getPos());
             sender.getScene().broadcastPacket(new PacketSceneEntityAppearNotify(sender));
-        } catch (Exception ignored) {
-            ignored.printStackTrace();
+        } else {
+            CommandHandler.sendTranslatedMessage(sender, "Failed to change the Element.");
         }
-
-
     }
 }

--- a/src/main/java/test/gc/switchele/commands/SwitchElement.java
+++ b/src/main/java/test/gc/switchele/commands/SwitchElement.java
@@ -8,19 +8,28 @@ import emu.grasscutter.data.excels.AvatarSkillDepotData;
 import emu.grasscutter.game.avatar.Avatar;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.server.packet.send.PacketSceneEntityAppearNotify;
+import emu.grasscutter.utils.Position;
 import test.gc.switchele.Switchele;
+import test.gc.switchele.VersionSupportHelper;
 
+import javax.annotation.Nullable;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.List;
 
-@Command(label = "switchelement", description = "Switch element for traveller", usage = "switchelement [White/Anemo/Geo/Electro/Dendro]", aliases = {"se"}, threading = true)
+@Command(label = "switchelement", usage = "switchelement [White/Anemo/Geo/Electro/Dendro]", aliases = {"se"}, threading = true)
 public class SwitchElement implements CommandHandler {
+
+    @Nullable
+    private static final Method getPositionMethod = VersionSupportHelper.getPositionMethod();
+    private static final String failedSuccessfullyMessage = "Successfully changed element to %s, but failed to reload scene. Manually reload scene to see the changed";
 
     private Element getElementFromString(String elementString) {
         return switch (elementString.toLowerCase()) {
             case "white", "common" -> Element.COMMON;
             case "fire", "pyro" -> Element.FIRE;
             case "water", "hydro" -> Element.WATER;
-            case "wind", "anemo" -> Element.WIND;
+            case "wind", "anemo", "air" -> Element.WIND;
             case "ice", "cryo" -> Element.ICE;
             case "rock", "geo" -> Element.ROCK;
             case "electro" -> Element.ELECTRO;
@@ -53,8 +62,6 @@ public class SwitchElement implements CommandHandler {
         }
 
         Element element = getElementFromString(args.get(0));
-
-
         if (element == null) {
             CommandHandler.sendMessage(sender, "Invalid element");
             return;
@@ -63,14 +70,25 @@ public class SwitchElement implements CommandHandler {
         boolean maleSuccess = changeAvatarElement(sender, GameConstants.MAIN_CHARACTER_MALE, element);
         boolean femaleSuccess = changeAvatarElement(sender, GameConstants.MAIN_CHARACTER_FEMALE, element);
         if (maleSuccess || femaleSuccess) {
-            String success = String.format("Successfully changed element to %s", element.name());
-            CommandHandler.sendMessage(sender, success);
+            if (getPositionMethod == null) {
+                String message = String.format(failedSuccessfullyMessage, element.name());
+                CommandHandler.sendMessage(sender, message);
+                return;
+            }
             int scene = sender.getSceneId();
-            sender.getWorld().transferPlayerToScene(sender, 1, sender.getPos());
-            sender.getWorld().transferPlayerToScene(sender, scene, sender.getPos());
-            sender.getScene().broadcastPacket(new PacketSceneEntityAppearNotify(sender));
+            String message;
+            try {
+                Position senderPos = (Position) getPositionMethod.invoke(sender);
+                sender.getWorld().transferPlayerToScene(sender, 1, senderPos);
+                sender.getWorld().transferPlayerToScene(sender, scene, senderPos);
+                sender.getScene().broadcastPacket(new PacketSceneEntityAppearNotify(sender));
+                message = String.format("Successfully changed element to %s", element.name());
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                message = String.format(failedSuccessfullyMessage, element.name());
+            }
+            CommandHandler.sendMessage(sender, message);
         } else {
-            CommandHandler.sendTranslatedMessage(sender, "Failed to change the Element.");
+            CommandHandler.sendMessage(sender, "Failed to change the Element.");
         }
     }
 }


### PR DESCRIPTION
Since I wanted to move it to a plugin today anyway, I thought, why not make this a pr.

What this does:
* Adds support for dendro (and other future elements)
* Allows using the internal element names
* Uses the propper skill repo, depending on the character
* adds the .gitignore file

I might also create another small pr to change `sender.getPos()` to `sender.getPosition()` and update the grasscutter api for the newest grasscutter dev changes, if its needed